### PR TITLE
Demo PR 2

### DIFF
--- a/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
+++ b/helper-cli/src/main/kotlin/commands/GenerateTimeoutErrorResolutionsCommand.kt
@@ -26,7 +26,6 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.file
 
-import org.ossreviewtoolkit.helper.utils.getScanIssues
 import org.ossreviewtoolkit.helper.utils.readOrtResult
 import org.ossreviewtoolkit.helper.utils.replaceConfig
 import org.ossreviewtoolkit.model.config.IssueResolution
@@ -70,11 +69,9 @@ internal class GenerateTimeoutErrorResolutionsCommand : CliktCommand(
 
         val resolutionProvider = DefaultResolutionProvider.create(ortResult, resolutionsFile)
 
-        val timeoutIssues = ortResult
-            .getScanIssues(omitExcluded)
-            .filter {
-                it.message.startsWith("ERROR: Timeout") && !resolutionProvider.isResolved(it)
-            }
+        val timeoutIssues = ortResult.getScannerIssues(omitExcluded).flatMapTo(mutableSetOf()) { it.value }.filter {
+            it.message.startsWith("ERROR: Timeout") && !resolutionProvider.isResolved(it)
+        }
 
         val generatedResolutions = timeoutIssues.mapTo(mutableSetOf()) {
             IssueResolution(

--- a/helper-cli/src/main/kotlin/utils/Extensions.kt
+++ b/helper-cli/src/main/kotlin/utils/Extensions.kt
@@ -33,10 +33,8 @@ import org.ossreviewtoolkit.analyzer.PackageManagerFactory
 import org.ossreviewtoolkit.downloader.Downloader
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Identifier
-import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.KnownProvenance
 import org.ossreviewtoolkit.model.OrtResult
-import org.ossreviewtoolkit.model.Package
 import org.ossreviewtoolkit.model.PackageCuration
 import org.ossreviewtoolkit.model.Project
 import org.ossreviewtoolkit.model.Provenance
@@ -232,24 +230,6 @@ internal fun KnownProvenance?.getSourceCodeOrigin(): SourceCodeOrigin? =
         is RepositoryProvenance -> SourceCodeOrigin.VCS
         else -> null
     }
-
-/**
- * Return all issues from scan results. Issues for excludes [Project]s or [Package]s are not returned if and only if
- * the given [omitExcluded] is true.
- */
-internal fun OrtResult.getScanIssues(omitExcluded: Boolean = false): List<Issue> {
-    val result = mutableListOf<Issue>()
-
-    getScanResults().forEach { (id, results) ->
-        if (!omitExcluded || !isExcluded(id)) {
-            results.forEach { scanResult ->
-                result += scanResult.summary.issues
-            }
-        }
-    }
-
-    return result
-}
 
 /**
  * Return all path excludes from this [OrtResult] represented as [RepositoryPathExcludes].

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-deduplicate-expected-output.yml
@@ -67,7 +67,7 @@ issue_resolutions:
   reason: "CANT_FIX_ISSUE"
   comment: "Resolved for illustration."
 - _id: 1
-  message: "A test issue\\."
+  message: "Example advisor error, resolved."
   reason: "CANT_FIX_ISSUE"
   comment: "A comment explaining why the issue can be ignored."
 issues:
@@ -229,11 +229,54 @@ issues:
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
-  message: "A test issue."
+  message: "Example advisor error, resolved."
   severity: "ERROR"
   resolutions:
   - 1
   pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 17
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor error."
+  severity: "ERROR"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 18
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor warning."
+  severity: "WARNING"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 19
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor hint."
+  severity: "HINT"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 20
+  timestamp: "2024-04-25T07:44:20.725613974Z"
+  type: "ANALYZER"
+  source: "Gradle"
+  message: "Example analyzer warning in included package."
+  severity: "WARNING"
+  pkg: 2
+  path: 0
+  how_to_fix: "Some how to fix text."
+- _id: 21
+  timestamp: "2024-04-25T07:44:20.725613974Z"
+  type: "ANALYZER"
+  source: "Gradle"
+  message: "Example analyzer warning in excluded package."
+  severity: "WARNING"
+  is_excluded: true
+  pkg: 3
+  path: 1
   how_to_fix: "Some how to fix text."
 scan_results:
 - _id: 0
@@ -555,8 +598,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 5
-  - 6
+  - 7
+  - 8
   levels:
   - 0
   - 1
@@ -602,7 +645,7 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 0
+  - 2
   levels:
   - 0
   scopes:
@@ -654,7 +697,7 @@ packages:
       comment: "Foobar is an imaginary dependency and offers a license choice"
       concluded_license: "GPL-2.0-only OR MIT"
   paths:
-  - 1
+  - 3
   levels:
   - 1
   scopes:
@@ -706,7 +749,7 @@ packages:
       comment: "H2 database offers a license choice"
       concluded_license: "MPL-2.0 OR EPL-1.0"
   paths:
-  - 2
+  - 4
   levels:
   - 1
   scopes:
@@ -753,8 +796,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 3
-  - 4
+  - 5
+  - 6
   levels:
   - 1
   - 2
@@ -837,7 +880,7 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 7
+  - 9
   levels:
   - 1
   scopes:
@@ -873,8 +916,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 8
-  - 9
+  - 10
+  - 11
   levels:
   - 0
   scopes:
@@ -883,58 +926,68 @@ packages:
   is_excluded: false
 paths:
 - _id: 0
+  pkg: 2
+  project: 1
+  scope: 0
+  path: []
+- _id: 1
   pkg: 3
   project: 1
   scope: 1
   path: []
-- _id: 1
+- _id: 2
+  pkg: 3
+  project: 1
+  scope: 1
+  path: []
+- _id: 3
   pkg: 4
   project: 1
   scope: 1
   path:
   - 3
-- _id: 2
+- _id: 4
   pkg: 5
   project: 1
   scope: 1
   path:
   - 3
-- _id: 3
+- _id: 5
   pkg: 6
   project: 1
   scope: 0
   path:
   - 2
-- _id: 4
+- _id: 6
   pkg: 6
   project: 1
   scope: 1
   path:
   - 9
   - 2
-- _id: 5
+- _id: 7
   pkg: 2
   project: 1
   scope: 0
   path: []
-- _id: 6
+- _id: 8
   pkg: 2
   project: 1
   scope: 1
   path:
   - 9
-- _id: 7
+- _id: 9
   pkg: 8
   project: 1
   scope: 1
   path:
   - 3
-- _id: 8
+- _id: 10
   pkg: 9
   project: 1
   scope: 0
   path: []
-- _id: 9
+- _id: 11
   pkg: 9
   project: 1
   scope: 1
@@ -953,6 +1006,8 @@ dependency_trees:
     - key: 3
       linkage: "DYNAMIC"
       pkg: 2
+      issues:
+      - 20
       children:
       - key: 4
         linkage: "DYNAMIC"
@@ -964,33 +1019,39 @@ dependency_trees:
       - key: 6
         linkage: "DYNAMIC"
         pkg: 2
-  - key: 7
+        children:
+        - key: 7
+          linkage: "DYNAMIC"
+          pkg: 6
+  - key: 8
     scope: 1
     scope_excludes:
     - 0
     children:
-    - key: 8
+    - key: 9
       linkage: "DYNAMIC"
       pkg: 3
+      issues:
+      - 21
       children:
-      - key: 9
-        linkage: "DYNAMIC"
-        pkg: 4
       - key: 10
         linkage: "DYNAMIC"
-        pkg: 5
+        pkg: 4
       - key: 11
         linkage: "DYNAMIC"
+        pkg: 5
+      - key: 12
+        linkage: "DYNAMIC"
         pkg: 8
-    - key: 12
+    - key: 13
       linkage: "DYNAMIC"
       pkg: 9
       children:
-      - key: 13
+      - key: 14
         linkage: "DYNAMIC"
         pkg: 2
         children:
-        - key: 14
+        - key: 15
           linkage: "DYNAMIC"
           pkg: 6
 rule_violation_resolutions:
@@ -1051,10 +1112,10 @@ statistics:
     rule_violation_resolutions: 1
     vulnerability_resolutions: 0
   open_issues:
-    errors: 4
-    warnings: 2
-    hints: 2
-    severe: 6
+    errors: 5
+    warnings: 4
+    hints: 3
+    severe: 9
   open_rule_violations:
     errors: 1
     warnings: 1
@@ -1145,15 +1206,15 @@ repository_configuration: "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/p
   \n  - pattern: \"analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat\"\
   \n    reason: \"DATA_FILE_OF\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason:\
   \ \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\
-  \nresolutions:\n  issues:\n  - message: \"A test issue\\\\.\"\n    reason: \"CANT_FIX_ISSUE\"\
-  \n    comment: \"A comment explaining why the issue can be ignored.\"\n  - message:\
-  \ \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"\
-  Resolved for illustration.\"\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\
-  \n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\
-  \nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR\
-  \ MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\
-  \n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\
-  \n"
+  \nresolutions:\n  issues:\n  - message: \"Example advisor error, resolved.\"\n \
+  \   reason: \"CANT_FIX_ISSUE\"\n    comment: \"A comment explaining why the issue\
+  \ can be ignored.\"\n  - message: \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\
+  \n    comment: \"Resolved for illustration.\"\n  rule_violations:\n  - message:\
+  \ \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2\
+  \ is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given:\
+  \ \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  -\
+  \ package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given:\
+  \ \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n"
 labels:
   job_parameters.JOB_PARAM_1: "label job param 1"
   job_parameters.JOB_PARAM_2: "label job param 2"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.json
@@ -91,7 +91,7 @@
     "comment" : "Resolved for illustration."
   }, {
     "_id" : 1,
-    "message" : "A test issue\\.",
+    "message" : "Example advisor error, resolved.",
     "reason" : "CANT_FIX_ISSUE",
     "comment" : "A comment explaining why the issue can be ignored."
   } ],
@@ -265,10 +265,58 @@
     "timestamp" : "1970-01-01T00:00:00Z",
     "type" : "ADVISOR",
     "source" : "VulnerableCode",
-    "message" : "A test issue.",
+    "message" : "Example advisor error, resolved.",
     "severity" : "ERROR",
     "resolutions" : [ 1 ],
     "pkg" : 2,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 17,
+    "timestamp" : "1970-01-01T00:00:00Z",
+    "type" : "ADVISOR",
+    "source" : "VulnerableCode",
+    "message" : "Example advisor error.",
+    "severity" : "ERROR",
+    "pkg" : 2,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 18,
+    "timestamp" : "1970-01-01T00:00:00Z",
+    "type" : "ADVISOR",
+    "source" : "VulnerableCode",
+    "message" : "Example advisor warning.",
+    "severity" : "WARNING",
+    "pkg" : 2,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 19,
+    "timestamp" : "1970-01-01T00:00:00Z",
+    "type" : "ADVISOR",
+    "source" : "VulnerableCode",
+    "message" : "Example advisor hint.",
+    "severity" : "HINT",
+    "pkg" : 2,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 20,
+    "timestamp" : "2024-04-25T07:44:20.725613974Z",
+    "type" : "ANALYZER",
+    "source" : "Gradle",
+    "message" : "Example analyzer warning in included package.",
+    "severity" : "WARNING",
+    "pkg" : 2,
+    "path" : 0,
+    "how_to_fix" : "Some how to fix text."
+  }, {
+    "_id" : 21,
+    "timestamp" : "2024-04-25T07:44:20.725613974Z",
+    "type" : "ANALYZER",
+    "source" : "Gradle",
+    "message" : "Example analyzer warning in excluded package.",
+    "severity" : "WARNING",
+    "is_excluded" : true,
+    "pkg" : 3,
+    "path" : 1,
     "how_to_fix" : "Some how to fix text."
   } ],
   "scan_results" : [ {
@@ -619,7 +667,7 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 5, 6 ],
+    "paths" : [ 7, 8 ],
     "levels" : [ 0, 1 ],
     "scopes" : [ 0, 1 ],
     "scan_results" : [ 5 ],
@@ -664,7 +712,7 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 0 ],
+    "paths" : [ 2 ],
     "levels" : [ 0 ],
     "scopes" : [ 1 ],
     "scan_results" : [ 2 ],
@@ -717,7 +765,7 @@
         "concluded_license" : "GPL-2.0-only OR MIT"
       }
     } ],
-    "paths" : [ 1 ],
+    "paths" : [ 3 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
     "is_excluded" : true,
@@ -771,7 +819,7 @@
         "concluded_license" : "MPL-2.0 OR EPL-1.0"
       }
     } ],
-    "paths" : [ 2 ],
+    "paths" : [ 4 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
     "scan_results" : [ 3 ],
@@ -817,7 +865,7 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 3, 4 ],
+    "paths" : [ 5, 6 ],
     "levels" : [ 1, 2 ],
     "scopes" : [ 0, 1 ],
     "scan_results" : [ 4 ],
@@ -904,7 +952,7 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 7 ],
+    "paths" : [ 9 ],
     "levels" : [ 1 ],
     "scopes" : [ 1 ],
     "scan_results" : [ 6 ],
@@ -942,67 +990,79 @@
       "revision" : "",
       "path" : ""
     },
-    "paths" : [ 8, 9 ],
+    "paths" : [ 10, 11 ],
     "levels" : [ 0 ],
     "scopes" : [ 0, 1 ],
     "is_excluded" : false
   } ],
   "paths" : [ {
     "_id" : 0,
+    "pkg" : 2,
+    "project" : 1,
+    "scope" : 0,
+    "path" : [ ]
+  }, {
+    "_id" : 1,
     "pkg" : 3,
     "project" : 1,
     "scope" : 1,
     "path" : [ ]
   }, {
-    "_id" : 1,
+    "_id" : 2,
+    "pkg" : 3,
+    "project" : 1,
+    "scope" : 1,
+    "path" : [ ]
+  }, {
+    "_id" : 3,
     "pkg" : 4,
     "project" : 1,
     "scope" : 1,
     "path" : [ 3 ]
   }, {
-    "_id" : 2,
+    "_id" : 4,
     "pkg" : 5,
     "project" : 1,
     "scope" : 1,
     "path" : [ 3 ]
   }, {
-    "_id" : 3,
+    "_id" : 5,
     "pkg" : 6,
     "project" : 1,
     "scope" : 0,
     "path" : [ 2 ]
   }, {
-    "_id" : 4,
+    "_id" : 6,
     "pkg" : 6,
     "project" : 1,
     "scope" : 1,
     "path" : [ 9, 2 ]
   }, {
-    "_id" : 5,
+    "_id" : 7,
     "pkg" : 2,
     "project" : 1,
     "scope" : 0,
     "path" : [ ]
   }, {
-    "_id" : 6,
+    "_id" : 8,
     "pkg" : 2,
     "project" : 1,
     "scope" : 1,
     "path" : [ 9 ]
   }, {
-    "_id" : 7,
+    "_id" : 9,
     "pkg" : 8,
     "project" : 1,
     "scope" : 1,
     "path" : [ 3 ]
   }, {
-    "_id" : 8,
+    "_id" : 10,
     "pkg" : 9,
     "project" : 1,
     "scope" : 0,
     "path" : [ ]
   }, {
-    "_id" : 9,
+    "_id" : 11,
     "pkg" : 9,
     "project" : 1,
     "scope" : 1,
@@ -1022,6 +1082,7 @@
         "key" : 3,
         "linkage" : "DYNAMIC",
         "pkg" : 2,
+        "issues" : [ 20 ],
         "children" : [ {
           "key" : 4,
           "linkage" : "DYNAMIC",
@@ -1050,6 +1111,7 @@
         "key" : 9,
         "linkage" : "DYNAMIC",
         "pkg" : 3,
+        "issues" : [ 21 ],
         "children" : [ {
           "key" : 10,
           "linkage" : "DYNAMIC",
@@ -1141,10 +1203,10 @@
       "vulnerability_resolutions" : 0
     },
     "open_issues" : {
-      "errors" : 4,
-      "warnings" : 2,
-      "hints" : 2,
-      "severe" : 6
+      "errors" : 5,
+      "warnings" : 4,
+      "hints" : 3,
+      "severe" : 9
     },
     "open_rule_violations" : {
       "errors" : 1,
@@ -1240,7 +1302,7 @@
   },
   "severe_issue_threshold" : "WARNING",
   "severe_rule_violation_threshold" : "WARNING",
-  "repository_configuration" : "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern: \"**/*.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\n  - pattern: \"analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat\"\n    reason: \"DATA_FILE_OF\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  issues:\n  - message: \"A test issue\\\\.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"A comment explaining why the issue can be ignored.\"\n  - message: \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"Resolved for illustration.\"\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n",
+  "repository_configuration" : "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/project/build.gradle\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"The project is an example.\"\n  - pattern: \"**/*.java\"\n    reason: \"EXAMPLE_OF\"\n    comment: \"These are example files.\"\n  - pattern: \"analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat\"\n    reason: \"DATA_FILE_OF\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason: \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\nresolutions:\n  issues:\n  - message: \"Example advisor error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"A comment explaining why the issue can be ignored.\"\n  - message: \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"Resolved for illustration.\"\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n",
   "labels" : {
     "job_parameters.JOB_PARAM_1" : "label job param 1",
     "job_parameters.JOB_PARAM_2" : "label job param 2",

--- a/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/evaluated-model-reporter-test-expected-output.yml
@@ -67,7 +67,7 @@ issue_resolutions:
   reason: "CANT_FIX_ISSUE"
   comment: "Resolved for illustration."
 - _id: 1
-  message: "A test issue\\."
+  message: "Example advisor error, resolved."
   reason: "CANT_FIX_ISSUE"
   comment: "A comment explaining why the issue can be ignored."
 issues:
@@ -229,11 +229,54 @@ issues:
   timestamp: "1970-01-01T00:00:00Z"
   type: "ADVISOR"
   source: "VulnerableCode"
-  message: "A test issue."
+  message: "Example advisor error, resolved."
   severity: "ERROR"
   resolutions:
   - 1
   pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 17
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor error."
+  severity: "ERROR"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 18
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor warning."
+  severity: "WARNING"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 19
+  timestamp: "1970-01-01T00:00:00Z"
+  type: "ADVISOR"
+  source: "VulnerableCode"
+  message: "Example advisor hint."
+  severity: "HINT"
+  pkg: 2
+  how_to_fix: "Some how to fix text."
+- _id: 20
+  timestamp: "2024-04-25T07:44:20.725613974Z"
+  type: "ANALYZER"
+  source: "Gradle"
+  message: "Example analyzer warning in included package."
+  severity: "WARNING"
+  pkg: 2
+  path: 0
+  how_to_fix: "Some how to fix text."
+- _id: 21
+  timestamp: "2024-04-25T07:44:20.725613974Z"
+  type: "ANALYZER"
+  source: "Gradle"
+  message: "Example analyzer warning in excluded package."
+  severity: "WARNING"
+  is_excluded: true
+  pkg: 3
+  path: 1
   how_to_fix: "Some how to fix text."
 scan_results:
 - _id: 0
@@ -555,8 +598,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 5
-  - 6
+  - 7
+  - 8
   levels:
   - 0
   - 1
@@ -602,7 +645,7 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 0
+  - 2
   levels:
   - 0
   scopes:
@@ -654,7 +697,7 @@ packages:
       comment: "Foobar is an imaginary dependency and offers a license choice"
       concluded_license: "GPL-2.0-only OR MIT"
   paths:
-  - 1
+  - 3
   levels:
   - 1
   scopes:
@@ -706,7 +749,7 @@ packages:
       comment: "H2 database offers a license choice"
       concluded_license: "MPL-2.0 OR EPL-1.0"
   paths:
-  - 2
+  - 4
   levels:
   - 1
   scopes:
@@ -753,8 +796,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 3
-  - 4
+  - 5
+  - 6
   levels:
   - 1
   - 2
@@ -837,7 +880,7 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 7
+  - 9
   levels:
   - 1
   scopes:
@@ -873,8 +916,8 @@ packages:
     revision: ""
     path: ""
   paths:
-  - 8
-  - 9
+  - 10
+  - 11
   levels:
   - 0
   scopes:
@@ -883,58 +926,68 @@ packages:
   is_excluded: false
 paths:
 - _id: 0
+  pkg: 2
+  project: 1
+  scope: 0
+  path: []
+- _id: 1
   pkg: 3
   project: 1
   scope: 1
   path: []
-- _id: 1
+- _id: 2
+  pkg: 3
+  project: 1
+  scope: 1
+  path: []
+- _id: 3
   pkg: 4
   project: 1
   scope: 1
   path:
   - 3
-- _id: 2
+- _id: 4
   pkg: 5
   project: 1
   scope: 1
   path:
   - 3
-- _id: 3
+- _id: 5
   pkg: 6
   project: 1
   scope: 0
   path:
   - 2
-- _id: 4
+- _id: 6
   pkg: 6
   project: 1
   scope: 1
   path:
   - 9
   - 2
-- _id: 5
+- _id: 7
   pkg: 2
   project: 1
   scope: 0
   path: []
-- _id: 6
+- _id: 8
   pkg: 2
   project: 1
   scope: 1
   path:
   - 9
-- _id: 7
+- _id: 9
   pkg: 8
   project: 1
   scope: 1
   path:
   - 3
-- _id: 8
+- _id: 10
   pkg: 9
   project: 1
   scope: 0
   path: []
-- _id: 9
+- _id: 11
   pkg: 9
   project: 1
   scope: 1
@@ -953,6 +1006,8 @@ dependency_trees:
     - key: 3
       linkage: "DYNAMIC"
       pkg: 2
+      issues:
+      - 20
       children:
       - key: 4
         linkage: "DYNAMIC"
@@ -976,6 +1031,8 @@ dependency_trees:
     - key: 9
       linkage: "DYNAMIC"
       pkg: 3
+      issues:
+      - 21
       children:
       - key: 10
         linkage: "DYNAMIC"
@@ -1055,10 +1112,10 @@ statistics:
     rule_violation_resolutions: 1
     vulnerability_resolutions: 0
   open_issues:
-    errors: 4
-    warnings: 2
-    hints: 2
-    severe: 6
+    errors: 5
+    warnings: 4
+    hints: 3
+    severe: 9
   open_rule_violations:
     errors: 1
     warnings: 1
@@ -1149,15 +1206,15 @@ repository_configuration: "---\nexcludes:\n  paths:\n  - pattern: \"sub/module/p
   \n  - pattern: \"analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat\"\
   \n    reason: \"DATA_FILE_OF\"\n  scopes:\n  - pattern: \"testCompile\"\n    reason:\
   \ \"TEST_DEPENDENCY_OF\"\n    comment: \"The scope only contains test dependencies.\"\
-  \nresolutions:\n  issues:\n  - message: \"A test issue\\\\.\"\n    reason: \"CANT_FIX_ISSUE\"\
-  \n    comment: \"A comment explaining why the issue can be ignored.\"\n  - message:\
-  \ \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\n    comment: \"\
-  Resolved for illustration.\"\n  rule_violations:\n  - message: \"Apache-2.0 hint\"\
-  \n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2 is not an issue.\"\
-  \nlicense_choices:\n  repository_license_choices:\n  - given: \"GPL-2.0-only OR\
-  \ MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  - package_id: \"Maven:com.h2database:h2:1.4.200\"\
-  \n    license_choices:\n    - given: \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\
-  \n"
+  \nresolutions:\n  issues:\n  - message: \"Example advisor error, resolved.\"\n \
+  \   reason: \"CANT_FIX_ISSUE\"\n    comment: \"A comment explaining why the issue\
+  \ can be ignored.\"\n  - message: \"Example error, resolved.\"\n    reason: \"CANT_FIX_ISSUE\"\
+  \n    comment: \"Resolved for illustration.\"\n  rule_violations:\n  - message:\
+  \ \"Apache-2.0 hint\"\n    reason: \"CANT_FIX_EXCEPTION\"\n    comment: \"Apache-2\
+  \ is not an issue.\"\nlicense_choices:\n  repository_license_choices:\n  - given:\
+  \ \"GPL-2.0-only OR MIT\"\n    choice: \"MIT\"\n  package_license_choices:\n  -\
+  \ package_id: \"Maven:com.h2database:h2:1.4.200\"\n    license_choices:\n    - given:\
+  \ \"MPL-2.0 OR EPL-1.0\"\n      choice: \"MPL-2.0\"\n"
 labels:
   job_parameters.JOB_PARAM_1: "label job param 1"
   job_parameters.JOB_PARAM_2: "label job param 2"

--- a/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/evaluated-model/src/funTest/assets/reporter-test-input.yml
@@ -33,7 +33,7 @@ repository:
         comment: "The scope only contains test dependencies."
     resolutions:
       issues:
-      - message: "A test issue\\."
+      - message: "Example advisor error, resolved."
         reason: "CANT_FIX_ISSUE"
         comment: "A comment explaining why the issue can be ignored."
       - message: "Example error, resolved."
@@ -104,6 +104,11 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in included package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.example.test:component:1.11"
@@ -114,6 +119,11 @@ analyzer:
       - name: "testCompile"
         dependencies:
         - id: "Ant:junit:junit:4.12"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in excluded package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:com.foobar:foobar:1.0"
           - id: "Maven:com.h2database:h2:1.4.200"
@@ -781,8 +791,20 @@ advisor:
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "VulnerableCode"
-            message: "A test issue."
+            message: "Example advisor error, resolved."
             severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor error."
+            severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor warning."
+            severity: "WARNING"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor hint."
+            severity: "HINT"
         defects: []
         vulnerabilities:
         - id: "VULCOID-VULNERABILITY_ID"
@@ -835,7 +857,7 @@ resolved_configuration:
         concluded_license: "MPL-2.0 OR EPL-1.0"
   resolutions:
     issues:
-    - message: "A test issue\\."
+    - message: "Example advisor error, resolved."
       reason: "CANT_FIX_ISSUE"
       comment: "A comment explaining why the issue can be ignored."
     - message: "Example error, resolved."

--- a/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/opossum/src/funTest/assets/reporter-test-input.yml
@@ -33,7 +33,7 @@ repository:
         comment: "The scope only contains test dependencies."
     resolutions:
       issues:
-      - message: "A test issue\\."
+      - message: "Example advisor error, resolved."
         reason: "CANT_FIX_ISSUE"
         comment: "A comment explaining why the issue can be ignored."
       - message: "Example error, resolved."
@@ -104,6 +104,11 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in included package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.example.test:component:1.11"
@@ -114,6 +119,11 @@ analyzer:
       - name: "testCompile"
         dependencies:
         - id: "Ant:junit:junit:4.12"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in excluded package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:com.foobar:foobar:1.0"
           - id: "Maven:com.h2database:h2:1.4.200"
@@ -781,8 +791,20 @@ advisor:
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "VulnerableCode"
-            message: "A test issue."
+            message: "Example advisor error, resolved."
             severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor error."
+            severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor warning."
+            severity: "WARNING"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor hint."
+            severity: "HINT"
         defects: []
         vulnerabilities:
         - id: "VULCOID-VULNERABILITY_ID"
@@ -835,7 +857,7 @@ resolved_configuration:
         concluded_license: "MPL-2.0 OR EPL-1.0"
   resolutions:
     issues:
-    - message: "A test issue\\."
+    - message: "Example advisor error, resolved."
       reason: "CANT_FIX_ISSUE"
       comment: "A comment explaining why the issue can be ignored."
     - message: "Example error, resolved."

--- a/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
+++ b/plugins/reporters/static-html/src/funTest/assets/reporter-test-input.yml
@@ -33,7 +33,7 @@ repository:
         comment: "The scope only contains test dependencies."
     resolutions:
       issues:
-      - message: "A test issue\\."
+      - message: "Example advisor error, resolved."
         reason: "CANT_FIX_ISSUE"
         comment: "A comment explaining why the issue can be ignored."
       - message: "Example error, resolved."
@@ -104,6 +104,11 @@ analyzer:
       - name: "compile"
         dependencies:
         - id: "Maven:org.apache.commons:commons-text:1.1"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in included package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:org.apache.commons:commons-lang3:3.5"
         - id: "Maven:org.example.test:component:1.11"
@@ -114,6 +119,11 @@ analyzer:
       - name: "testCompile"
         dependencies:
         - id: "Ant:junit:junit:4.12"
+          issues:
+          - timestamp: "2024-04-25T07:44:20.725613974Z"
+            source: "Gradle"
+            message: "Example analyzer warning in excluded package."
+            severity: "WARNING"
           dependencies:
           - id: "Maven:com.foobar:foobar:1.0"
           - id: "Maven:com.h2database:h2:1.4.200"
@@ -781,8 +791,20 @@ advisor:
           issues:
           - timestamp: "1970-01-01T00:00:00Z"
             source: "VulnerableCode"
-            message: "A test issue."
+            message: "Example advisor error, resolved."
             severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor error."
+            severity: "ERROR"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor warning."
+            severity: "WARNING"
+          - timestamp: "1970-01-01T00:00:00Z"
+            source: "VulnerableCode"
+            message: "Example advisor hint."
+            severity: "HINT"
         defects: []
         vulnerabilities:
         - id: "VULCOID-VULNERABILITY_ID"
@@ -835,7 +857,7 @@ resolved_configuration:
         concluded_license: "MPL-2.0 OR EPL-1.0"
   resolutions:
     issues:
-    - message: "A test issue\\."
+    - message: "Example advisor error, resolved."
       reason: "CANT_FIX_ISSUE"
       comment: "A comment explaining why the issue can be ignored."
     - message: "Example error, resolved."

--- a/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
+++ b/plugins/reporters/static-html/src/funTest/assets/static-html-reporter-test-expected-output.html
@@ -454,7 +454,9 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
          <h2>Index</h2>
          <ul>
             <li><a href="#rule-violation-summary">Rule Violation Summary (1 errors, 1 warnings, 0 hints to resolve)</a></li>
-            <li><a href="#issue-summary">Issue Summary (5 errors, 2 warnings, 2 hints to resolve)</a></li>
+            <li><a href="#analyzer-issue-summary">Analyzer Issue Summary (1 errors, 2 warnings, 1 hints to resolve)</a></li>
+            <li><a href="#scanner-issue-summary">Scanner Issue Summary (3 errors, 1 warnings, 1 hints to resolve)</a></li>
+            <li><a href="#advisor-issue-summary">Advisor Issue Summary (1 errors, 1 warnings, 1 hints to resolve)</a></li>
             <li><a href="#Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0">Gradle:org.ossreviewtoolkit:nested-fake-project:1.0.0 
                   <div class="ort-reason">Excluded: EXAMPLE_OF - The project is an example.</div></a></li>
             <li><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a></li>
@@ -531,175 +533,273 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                </tr>
             </tbody>
          </table>
-         <h2 id="issue-summary">Issue Summary (5 errors, 2 warnings, 2 hints to resolve)</h2>
+         <h2 id="analyzer-issue-summary">Analyzer Issue Summary (1 errors, 2 warnings, 1 hints to resolve)</h2>
          <p>Issues from excluded components are not shown in this summary.</p>
-         <h3>Packages</h3>
          <table class="ort-report-table">
             <thead>
                <tr>
                   <th>#</th>
                   <th>Package</th>
-                  <th>Analyzer Issues</th>
-                  <th>Scanner Issues</th>
+                  <th>Message</th>
                </tr>
             </thead>
             <tbody>
-               <tr class="ort-error" id="issue-1">
-                  <td><a href="#issue-1">1</a></td>
+               <tr class="ort-error" id="analyzer-issue-summary-1">
+                  <td><a href="#analyzer-issue-summary-1">1</a></td>
                   <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
-                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a><ul>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [ERROR]: Gradle - Example error.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example warning.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [HINT]: Gradle - Example hint.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                     </ul>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [ERROR]: Gradle - Example error.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
                   </td>
-                  <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0">Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</a><ul>
-                        <li>
-                           <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for
-                              'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
-                              Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
-                              while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/included-file.dat'.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
-                              while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/excluded-file.dat'.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [ERROR]: FakeScanner - Example error.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: FakeScanner - Example warning.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                        <li>
-                           <p>2024-04-25T07:44:20.725613974Z [HINT]: FakeScanner - Example hint.</p>
-                           <p></p>
-                        </li>
-                        <details>
-                           <summary>How to fix</summary>
-                           <ul>
-                              
-                              <li><em>Step 1</em></li>
-                              
-                              <li><strong>Step 2</strong></li>
-                              
-                              <li><em><strong>Step 3</strong></em>
-                                 <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
-                              </ul>
-                           </details>
-                     </ul>
+               </tr>
+               <tr class="ort-warning" id="analyzer-issue-summary-2">
+                  <td><a href="#analyzer-issue-summary-2">2</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example warning.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-warning" id="analyzer-issue-summary-3">
+                  <td><a href="#analyzer-issue-summary-3">3</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in included
+                        package.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-hint" id="analyzer-issue-summary-4">
+                  <td><a href="#analyzer-issue-summary-4">4</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [HINT]: Gradle - Example hint.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
+         <h2 id="scanner-issue-summary">Scanner Issue Summary (3 errors, 1 warnings, 1 hints to resolve)</h2>
+         <p>Issues from excluded components are not shown in this summary.</p>
+         <table class="ort-report-table">
+            <thead>
+               <tr>
+                  <th>#</th>
+                  <th>Package</th>
+                  <th>Message</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr class="ort-error" id="scanner-issue-summary-1">
+                  <td><a href="#scanner-issue-summary-1">1</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>Unknown time [ERROR]: Dummy - DownloadException: No source artifact URL provided for
+                        'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.<br>Caused by: DownloadException: No VCS URL provided for 'Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0'.
+                        Please make sure the published POM file includes the SCM connection, see: https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-error" id="scanner-issue-summary-2">
+                  <td><a href="#scanner-issue-summary-2">2</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-22T10:36:10.661544294Z [ERROR]: FakeScanner - ERROR: Timeout after 300 seconds
+                        while scanning file 'analyzer/src/funTest/assets/projects/synthetic/gradle/lib/included-file.dat'.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-error" id="scanner-issue-summary-3">
+                  <td><a href="#scanner-issue-summary-3">3</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [ERROR]: FakeScanner - Example error.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-warning" id="scanner-issue-summary-4">
+                  <td><a href="#scanner-issue-summary-4">4</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [WARNING]: FakeScanner - Example warning.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-hint" id="scanner-issue-summary-5">
+                  <td><a href="#scanner-issue-summary-5">5</a></td>
+                  <td>Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0</td>
+                  <td>
+                     <p>2024-04-25T07:44:20.725613974Z [HINT]: FakeScanner - Example hint.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
+         <h2 id="advisor-issue-summary">Advisor Issue Summary (1 errors, 1 warnings, 1 hints to resolve)</h2>
+         <p>Issues from excluded components are not shown in this summary.</p>
+         <table class="ort-report-table">
+            <thead>
+               <tr>
+                  <th>#</th>
+                  <th>Package</th>
+                  <th>Message</th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr class="ort-error" id="advisor-issue-summary-1">
+                  <td><a href="#advisor-issue-summary-1">1</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>
+                     <p>Unknown time [ERROR]: VulnerableCode - Example advisor error.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-warning" id="advisor-issue-summary-2">
+                  <td><a href="#advisor-issue-summary-2">2</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>
+                     <p>Unknown time [WARNING]: VulnerableCode - Example advisor warning.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
+                  </td>
+               </tr>
+               <tr class="ort-hint" id="advisor-issue-summary-3">
+                  <td><a href="#advisor-issue-summary-3">3</a></td>
+                  <td>Maven:org.apache.commons:commons-text:1.1</td>
+                  <td>
+                     <p>Unknown time [HINT]: VulnerableCode - Example advisor hint.</p>
+                     <details>
+                        <summary>How to fix</summary>
+                        <ul>
+                           
+                           <li><em>Step 1</em></li>
+                           
+                           <li><strong>Step 2</strong></li>
+                           
+                           <li><em><strong>Step 3</strong></em>
+                              <code>Some long issue resolution text to verify that overflow:scroll is working as expected.</code></li>
+                           </ul>
+                        </details>
                   </td>
                </tr>
             </tbody>
@@ -895,7 +995,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                      </ul>
                   </td>
                </tr>
-               <tr class="ort-success ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">
+               <tr class="ort-error ort-excluded" id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">
                   <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-2">2</a></td>
                   <td>Ant:junit:junit:4.12</td>
                   <td>
@@ -916,7 +1016,12 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                      </dl>
                   </td>
                   <td>
-                     <ul></ul>
+                     <ul>
+                        <li>
+                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in excluded
+                              package.</p>
+                        </li>
+                     </ul>
                   </td>
                   <td>
                      <ul></ul>
@@ -1014,7 +1119,7 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                      <ul></ul>
                   </td>
                </tr>
-               <tr class="ort-success " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">
+               <tr class="ort-error " id="Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">
                   <td><a href="#Gradle:org.ossreviewtoolkit.gradle.example:lib:1.0.0-pkg-6">6</a></td>
                   <td>Maven:org.apache.commons:commons-text:1.1</td>
                   <td>
@@ -1036,7 +1141,12 @@ Prism.languages.yaml={scalar:{pattern:/([\-:]\s*(?:![^\s]+)?[ \t]*[|>])[ \t]*(?:
                      </dl>
                   </td>
                   <td>
-                     <ul></ul>
+                     <ul>
+                        <li>
+                           <p>2024-04-25T07:44:20.725613974Z [WARNING]: Gradle - Example analyzer warning in included
+                              package.</p>
+                        </li>
+                     </ul>
                   </td>
                   <td>
                      <ul></ul>
@@ -1109,7 +1219,7 @@ excludes:
     comment: "The scope only contains test dependencies."
 resolutions:
   issues:
-  - message: "A test issue\\."
+  - message: "Example advisor error, resolved."
     reason: "CANT_FIX_ISSUE"
     comment: "A comment explaining why the issue can be ignored."
   - message: "Example error, resolved."

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModel.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModel.kt
@@ -33,7 +33,6 @@ import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.licenses.ResolvedLicense
-import org.ossreviewtoolkit.utils.common.zipWithCollections
 import org.ossreviewtoolkit.utils.spdx.SpdxExpression
 
 internal fun Collection<ReportTableModel.ResolvableIssue>.containsUnresolved() = any { !it.isResolved }
@@ -57,7 +56,17 @@ internal data class ReportTableModel(
     /**
      * An [IssueTable] containing all dependencies that caused issues.
      */
-    val issueSummary: IssueTable,
+    val analyzerIssueSummary: IssueTable,
+
+    /**
+     * A [IssueTable] containing all scanner issues.
+     */
+    val scannerIssueSummary: IssueTable,
+
+    /**
+     * A [IssueTable] containing all advisor issues.
+     */
+    val advisorIssueSummary: IssueTable,
 
     /**
      * The [ProjectTable]s containing the dependencies for each [Project].
@@ -143,47 +152,31 @@ internal data class ReportTableModel(
     )
 
     data class IssueTable(
+        val type: Type,
         val rows: List<IssueRow>
     ) {
-        val errorCount: Int
-        val warningCount: Int
-        val hintCount: Int
+        val errorCount = rows.count { it.issue.severity == Severity.ERROR }
+        val warningCount = rows.count { it.issue.severity == Severity.WARNING }
+        val hintCount = rows.count { it.issue.severity == Severity.HINT }
 
-        init {
-            val unresolvedIssues = rows.flatMap {
-                it.analyzerIssues.flatMap { (_, issues) -> issues } +
-                    it.scanIssues.flatMap { (_, issues) -> issues }
-            }.filterNot { it.isResolved }.groupBy { it.severity }
-
-            errorCount = unresolvedIssues[Severity.ERROR].orEmpty().size
-            warningCount = unresolvedIssues[Severity.WARNING].orEmpty().size
-            hintCount = unresolvedIssues[Severity.HINT].orEmpty().size
+        enum class Type {
+            ANALYZER,
+            SCANNER,
+            ADVISOR
         }
     }
 
     data class IssueRow(
         /**
-         * The identifier of the package.
-         */
-        val id: Identifier,
-
-        /**
          * All analyzer issues related to this package, grouped by the [Identifier] of the [Project] they appear in.
          */
-        val analyzerIssues: SortedMap<Identifier, List<ResolvableIssue>>,
+        val issue: ResolvableIssue,
 
         /**
-         * All scan issues related to this package, grouped by the [Identifier] of the [Project] they appear in.
+         * The identifier of the package the issue corresponds to.
          */
-        val scanIssues: SortedMap<Identifier, List<ResolvableIssue>>
-    ) {
-        fun merge(other: IssueRow): IssueRow =
-            IssueRow(
-                id = id,
-                analyzerIssues = analyzerIssues.zipWithCollections(other.analyzerIssues).toSortedMap(),
-                scanIssues = scanIssues.zipWithCollections(other.scanIssues).toSortedMap()
-            )
-    }
+        val id: Identifier
+    )
 
     data class ResolvableIssue(
         val source: String,

--- a/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
+++ b/plugins/reporters/static-html/src/main/kotlin/ReportTableModelMapper.kt
@@ -31,7 +31,6 @@ import org.ossreviewtoolkit.model.config.ScopeExclude
 import org.ossreviewtoolkit.model.licenses.LicenseView
 import org.ossreviewtoolkit.model.orEmpty
 import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.DependencyRow
-import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.IssueRow
 import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.IssueTable
 import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.ProjectTable
 import org.ossreviewtoolkit.plugins.reporters.statichtml.ReportTableModel.ResolvableIssue
@@ -44,8 +43,6 @@ import org.ossreviewtoolkit.reporter.ReporterInput
  */
 internal object ReportTableModelMapper {
     fun map(input: ReporterInput): ReportTableModel {
-        val issueSummaryRows = mutableMapOf<Identifier, IssueRow>()
-
         val analyzerResult = input.ortResult.analyzer?.result
         val excludes = input.ortResult.getExcludes()
 
@@ -76,7 +73,7 @@ internal object ReportTableModelMapper {
 
                 val pkg = input.ortResult.getPackageOrProject(id)?.metadata
 
-                val row = DependencyRow(
+                DependencyRow(
                     id = id,
                     sourceArtifact = pkg?.sourceArtifact.orEmpty(),
                     vcsInfo = pkg?.vcsProcessed.orEmpty(),
@@ -96,32 +93,6 @@ internal object ReportTableModelMapper {
                         it.toResolvableIssue(input.ortResult, input.howToFixTextProvider)
                     }
                 )
-
-                val isRowExcluded = input.ortResult.isExcluded(row.id)
-                val unresolvedAnalyzerIssues = row.analyzerIssues.filterUnresolved().sortedByDescending { it.severity }
-                val unresolvedScanIssues = row.scanIssues.filterUnresolved().sortedByDescending { it.severity }
-
-                if ((unresolvedAnalyzerIssues.isNotEmpty() || unresolvedScanIssues.isNotEmpty())
-                    && !isRowExcluded
-                ) {
-                    val issueRow = IssueRow(
-                        id = row.id,
-                        analyzerIssues = if (unresolvedAnalyzerIssues.isNotEmpty()) {
-                            sortedMapOf(project.id to unresolvedAnalyzerIssues)
-                        } else {
-                            sortedMapOf()
-                        },
-                        scanIssues = if (unresolvedScanIssues.isNotEmpty()) {
-                            sortedMapOf(project.id to unresolvedScanIssues)
-                        } else {
-                            sortedMapOf()
-                        }
-                    )
-
-                    issueSummaryRows[row.id] = issueSummaryRows[issueRow.id]?.merge(issueRow) ?: issueRow
-                }
-
-                row
             }
 
             ProjectTable(
@@ -130,8 +101,6 @@ internal object ReportTableModelMapper {
                 pathExcludes
             )
         }.orEmpty().toSortedMap(compareBy { it.id })
-
-        val issueSummaryTable = IssueTable(issueSummaryRows.values.sortedBy { it.id })
 
         // TODO: Use the prefixes up until the first '.' (which below get discarded) for some visual grouping in the
         //       report.
@@ -145,7 +114,9 @@ internal object ReportTableModelMapper {
             input.ortResult.repository.vcsProcessed,
             input.ortResult.repository.config,
             ruleViolations,
-            issueSummaryTable,
+            getAnalyzerIssueSummaryTable(input),
+            getScannerIssueSummaryTable(input),
+            getAdvisorIssueSummaryTable(input),
             projectTables,
             labels
         )
@@ -159,8 +130,6 @@ private val VIOLATION_COMPARATOR = compareBy<ResolvableViolation> { it.isResolve
     .thenBy { it.violation.license.toString() }
     .thenBy { it.violation.message }
     .thenBy { it.resolutionDescription }
-
-private fun Collection<ResolvableIssue>.filterUnresolved() = filter { !it.isResolved }
 
 private fun Project.getScopesForDependencies(
     excludes: Excludes,
@@ -213,4 +182,27 @@ private fun RuleViolation.toResolvableViolation(ortResult: OrtResult): Resolvabl
         },
         isResolved = resolutions.isNotEmpty()
     )
+}
+
+private fun getAnalyzerIssueSummaryTable(input: ReporterInput): IssueTable =
+    input.ortResult.getAnalyzerIssues(omitExcluded = true, omitResolved = true)
+        .toIssueSummaryTable(IssueTable.Type.ANALYZER, input)
+
+private fun getScannerIssueSummaryTable(input: ReporterInput): IssueTable =
+    input.ortResult.getScannerIssues(omitExcluded = true, omitResolved = true)
+        .toIssueSummaryTable(IssueTable.Type.SCANNER, input)
+
+private fun getAdvisorIssueSummaryTable(input: ReporterInput): IssueTable =
+    input.ortResult.getAdvisorIssues(omitExcluded = true, omitResolved = true)
+        .toIssueSummaryTable(IssueTable.Type.ADVISOR, input)
+
+private fun Map<Identifier, Set<Issue>>.toIssueSummaryTable(type: IssueTable.Type, input: ReporterInput): IssueTable {
+    val rows = flatMap { (id, issues) ->
+        issues.map { issue ->
+            val resolvableIssue = issue.toResolvableIssue(input.ortResult, input.howToFixTextProvider)
+            ReportTableModel.IssueRow(resolvableIssue, id)
+        }
+    }.sortedWith(compareByDescending<ReportTableModel.IssueRow> { it.issue.severity }.thenBy { it.id })
+
+    return IssueTable(type, rows)
 }


### PR DESCRIPTION
refactor(static-html): Align on the term "rule violation"

Consistently name it rule violations.



refactor(static-html): Move the `p` tag out of `issueDescription()`

Simplify an upcoming change.



test(reporters): Add analyzer issues to package references

Make the tests cover this case as well.



refactor(model): Factor out `filterIssues()`

Prepare for re-use in an upcoming change.



refactor(model): Expose sparate `getIssues()` for related ORT stages

Prepare for re-use in upcoming changes.



feat(static-html): Re-design the summary of issues

Previously, there was a single issues table containing analyzer and scanner issues. A single row was dedicated to a project or package and contained all corresponding analyzer and scan issues. So, one of its design goals must have been to make the set of issues corresponding to any project or package easy to grasp / obvious. However, this design also has a couple of shortcomings:

1. The view cannot be extended to show advisor issues, because that would require adding another column which would lead to too small columns on smaller or medium sized screens.
2. Issues may be shown multiple times if they relate to multiple projects. This can render the number of issues to be resolved, shown in the issue summary title, less meaningful.
3. Issues cannot be ordered by severity.
4. It's tricky to style a row WRT the severity, because each row may contain multiple issues differing in their severity.

This change changes the approach as follows:

1. Split-up the issues table into one table per stage, analyzer and scanner.
2. Make each row dedicated to a single issue.
3. Order issues by their severity.

This allows to easily go through the issues for each stage separately, in order of the respective severity, which aligns with the natural order in which issues are being worked on. The code becomes quite a bit simpler, as the overall approach is simpler and the table becomes more consistent with the rule violation summary table, which also has the approach of one line per violation. While the link to the related entries in the project tables is now missing, the new approach is easily extensible by such links. For example, a column dedicated to these links can be added. Finally, as the issue getters from `OrtResult` are now used, issues with excluded affected paths are now omitted from the summary view.



test(reports): Add a couple of advisor issues to reporter test assets

Make the tests cover also unresolved errors, warnings and hints. While at it, adjust the message of the resolved issue to be more speaking.



feat(static-html): Add an advisor issue summary table

Show advisor issues analog to analyzer and scanner issues.